### PR TITLE
Support dev branches during code freeze

### DIFF
--- a/index.js
+++ b/index.js
@@ -27,15 +27,18 @@ async function run() {
       pull_number: github.context.payload.pull_request.number
     });
     const prRepo = github.context.payload.pull_request.base.repo;
+    const prBranch = github.context.payload.pull_request.base.ref;
     const prUser = pr.user.login;
     const prTitle = pr.title;
-    core.info(`Pull Request ${owner}/${repo}/${pr.number} by ${prUser} has title: "${prTitle}"`);
+    core.info(`Pull Request ${owner}/${repo}/${pr.number} on ${prBranch} by ${prUser} has title: "${prTitle}"`);
 
     // validate PR title
     if (prRepo.private) {
-      // implement a code freeze by uncommentig these two lines
-      updateStatus(client, owner, repo, pr, GROUP_PR_TITLE, "failure", "Repo closed");
-      return;
+      // implement a code freeze by uncommentig these four lines
+      if (prRef == 'main') {
+        updateStatus(client, owner, repo, pr, GROUP_PR_TITLE, "failure", "Repo closed");
+        return;
+      }
       // normal rules outside a code freeze
       if (isDependabot(prUser) || isOgbot(prUser)) {
         core.info("PR is from dependabot/ogbot");

--- a/index.js
+++ b/index.js
@@ -35,7 +35,7 @@ async function run() {
     // validate PR title
     if (prRepo.private) {
       // implement a code freeze by uncommentig these four lines
-      if (prRef == 'main') {
+      if (prBranch == 'main') {
         updateStatus(client, owner, repo, pr, GROUP_PR_TITLE, "failure", "Repo closed");
         return;
       }


### PR DESCRIPTION
Allow PRs to be merged normally to a branch other than `main` during a code freeze. Manual test performed in Treasury.

OGBot builds will always fail at present, this is normal