### PR TITLE
Block autoapproval on bot-raised PRs with non-bot changes

### DIFF
--- a/index.js
+++ b/index.js
@@ -66,9 +66,11 @@ async function run() {
       }
     }
 
-    // approve PR raised by bot
-    if (isDependabot(prUser) || isOgbot(prUser)) {
-      core.info("Approving PR raised by ogbot/dependabot");
+    // Approve PR if both the PR itself and its latest commit
+    // were raised by a bot.
+    const mostRecentCommitAuthor = pr.head.user.login
+    if ([prUser, mostRecentCommitAuthor].every(login => isDependabot(login) || isOgbot(login))) {
+      core.info("Approving PR and commit raised by ogbot/dependabot");
       return client.pulls.createReview({
         owner,
         repo,


### PR DESCRIPTION
Blocks OGBot from autoapproving PRs that were raised by bots, but which have human-authored commits at the top of the PR to prevent commiting unreviewed code to main.