### PR TITLE
Fix autoapprovals on bot-raised PRs

### DIFF
--- a/index.js
+++ b/index.js
@@ -68,7 +68,14 @@ async function run() {
 
     // Approve PR if both the PR itself and its latest commit
     // were raised by a bot.
-    const mostRecentCommitAuthor = pr.head.user.login
+    const { data: latestCommit } = await client.git.getCommit({
+      owner,
+      repo,
+      commit_sha: pr.head.sha
+    });
+    // A Git commit does not necessarily have to be associated with a GitHub login,
+    // and so 'login' is not a field we can extract. Bots we use have the same 'name' as 'login', so we use that instead.
+    const mostRecentCommitAuthor = latestCommit.author.name;
     if ([prUser, mostRecentCommitAuthor].every(login => isDependabot(login) || isOgbot(login))) {
       core.info("Approving PR and commit raised by ogbot/dependabot");
       return client.pulls.createReview({


### PR DESCRIPTION
The PR objects we've been extracting fields from does not include commit-specific information. We need to query the `commits` API instead.